### PR TITLE
Fix for showing the gif instead of the placeholder jpg

### DIFF
--- a/src/codinglove.coffee
+++ b/src/codinglove.coffee
@@ -47,7 +47,7 @@ send_meme = (message, location, response_handler)->
       location = response.headers['location']
       return send_meme(message, location, response_handler)
 
-    img_src = get_meme_image(body, ".post img")
+    img_src = get_meme_image(body, ".post img").replace(/.jpg/g, '.gif')
 
     txt = get_meme_txt(body, ".post h3 a")
 


### PR DESCRIPTION
The site has a placeholder jpg that it then replaces with the gif, and sometimes the script would show the jpg instead of the gif. This fixes that, hopefully.
